### PR TITLE
fix: make MultiSelect search match option value

### DIFF
--- a/src/components/ui/multi-select.test.tsx
+++ b/src/components/ui/multi-select.test.tsx
@@ -6,7 +6,11 @@ import { MultiSelect } from './multi-select'
 
 // Keep cmdk-based Command real; mock Radix/visual-only wrappers for stability.
 vi.mock('@/components/ui/button', () => ({
-  Button: ({ children, onClick, ...props }: any) => (
+  Button: ({
+    children,
+    onClick,
+    ...props
+  }: React.PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement>>) => (
     <button onClick={onClick} {...props}>
       {children}
     </button>
@@ -14,20 +18,27 @@ vi.mock('@/components/ui/button', () => ({
 }))
 
 vi.mock('@/components/ui/badge', () => ({
-  Badge: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+  Badge: ({
+    children,
+    ...props
+  }: React.PropsWithChildren<React.HTMLAttributes<HTMLSpanElement>>) => (
+    <span {...props}>{children}</span>
+  ),
 }))
 
 vi.mock('@/components/ui/separator.tsx', () => ({
-  Separator: (props: any) => <div data-testid="separator" {...props} />,
+  Separator: (props: React.HTMLAttributes<HTMLDivElement>) => (
+    <div data-testid="separator" {...props} />
+  ),
 }))
 
 vi.mock('lucide-react', () => ({
-  Search: (props: any) => <span {...props} />,
-  CheckIcon: (props: any) => <span {...props} />,
-  ChevronDown: (props: any) => <span {...props} />,
-  WandSparkles: (props: any) => <span {...props} />,
-  XCircle: (props: any) => <span {...props} />,
-  XIcon: (props: any) => <span {...props} />,
+  Search: (props: React.HTMLAttributes<HTMLSpanElement>) => <span {...props} />,
+  CheckIcon: (props: React.HTMLAttributes<HTMLSpanElement>) => <span {...props} />,
+  ChevronDown: (props: React.HTMLAttributes<HTMLSpanElement>) => <span {...props} />,
+  WandSparkles: (props: React.HTMLAttributes<HTMLSpanElement>) => <span {...props} />,
+  XCircle: (props: React.HTMLAttributes<HTMLSpanElement>) => <span {...props} />,
+  XIcon: (props: React.HTMLAttributes<HTMLSpanElement>) => <span {...props} />,
 }))
 
 vi.mock('@/components/ui/popover', async () => {
@@ -35,13 +46,16 @@ vi.mock('@/components/ui/popover', async () => {
 
   const Ctx = React.createContext<{ open: boolean }>({ open: false })
 
-  const Popover = ({ children, open }: any) => (
+  const Popover = ({
+    children,
+    open,
+  }: React.PropsWithChildren<{ open?: boolean }>) => (
     <Ctx.Provider value={{ open: !!open }}>{children}</Ctx.Provider>
   )
 
-  const PopoverTrigger = ({ children }: any) => <>{children}</>
+  const PopoverTrigger = ({ children }: React.PropsWithChildren) => <>{children}</>
 
-  const PopoverContent = ({ children }: any) => {
+  const PopoverContent = ({ children }: React.PropsWithChildren) => {
     const { open } = React.useContext(Ctx)
     if (!open) return null
     return <div data-testid="popover-content">{children}</div>

--- a/src/components/ui/multi-select.test.tsx
+++ b/src/components/ui/multi-select.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent, screen } from '@testing-library/react'
+
+import { MultiSelect } from './multi-select'
+
+// Keep cmdk-based Command real; mock Radix/visual-only wrappers for stability.
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, ...props }: any) => (
+    <button onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock('@/components/ui/badge', () => ({
+  Badge: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+}))
+
+vi.mock('@/components/ui/separator.tsx', () => ({
+  Separator: (props: any) => <div data-testid="separator" {...props} />,
+}))
+
+vi.mock('lucide-react', () => ({
+  Search: (props: any) => <span {...props} />,
+  CheckIcon: (props: any) => <span {...props} />,
+  ChevronDown: (props: any) => <span {...props} />,
+  WandSparkles: (props: any) => <span {...props} />,
+  XCircle: (props: any) => <span {...props} />,
+  XIcon: (props: any) => <span {...props} />,
+}))
+
+vi.mock('@/components/ui/popover', async () => {
+  const React = (await import('react')).default
+
+  const Ctx = React.createContext<{ open: boolean }>({ open: false })
+
+  const Popover = ({ children, open }: any) => (
+    <Ctx.Provider value={{ open: !!open }}>{children}</Ctx.Provider>
+  )
+
+  const PopoverTrigger = ({ children }: any) => <>{children}</>
+
+  const PopoverContent = ({ children }: any) => {
+    const { open } = React.useContext(Ctx)
+    if (!open) return null
+    return <div data-testid="popover-content">{children}</div>
+  }
+
+  return { Popover, PopoverTrigger, PopoverContent }
+})
+
+describe('MultiSelect', () => {
+  it('filters options by search input (e.g., Food -> Food & Drink)', () => {
+    const onValueChange = vi.fn()
+
+    render(
+      <MultiSelect
+        options={[
+          { label: 'Dining', value: 'Dining' },
+          // Regression: cmdk search should match on the item's `value` (not only visible label text).
+          // This will fail unless we pass an explicit `value` prop to each CommandItem.
+          { label: 'F&D', value: 'Food & Drink' },
+          { label: 'Groceries', value: 'Groceries' },
+        ]}
+        onValueChange={onValueChange}
+        defaultValue={[]}
+        placeholder="Select categories"
+      />,
+    )
+
+    // Open popover
+    fireEvent.click(screen.getByRole('button', { name: /select categories/i }))
+
+    const input = screen.getByPlaceholderText('Search...')
+    fireEvent.change(input, { target: { value: 'Food' } })
+
+    expect(screen.getByRole('option', { name: 'F&D' })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'Dining' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'Groceries' })).not.toBeInTheDocument()
+  })
+
+  it('filters options by search input (e.g., Din -> Dining)', () => {
+    const onValueChange = vi.fn()
+
+    render(
+      <MultiSelect
+        options={[
+          { label: 'Dining', value: 'Dining' },
+          { label: 'Food & Drink', value: 'Food & Drink' },
+          { label: 'Groceries', value: 'Groceries' },
+        ]}
+        onValueChange={onValueChange}
+        defaultValue={[]}
+        placeholder="Select categories"
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /select categories/i }))
+
+    const input = screen.getByPlaceholderText('Search...')
+    // cmdk does fuzzy matching; use a strict-enough query that shouldn't match "Drink"
+    fireEvent.change(input, { target: { value: 'Dining' } })
+
+    expect(screen.getByRole('option', { name: 'Dining' })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'Food & Drink' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'Groceries' })).not.toBeInTheDocument()
+  })
+})

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -1,14 +1,14 @@
 // src/components/multi-select.tsx
 
 import * as React from "react";
-import {cva, type VariantProps} from "class-variance-authority";
-import {CheckIcon, ChevronDown, WandSparkles, XCircle, XIcon,} from "lucide-react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { CheckIcon, ChevronDown, WandSparkles, XCircle, XIcon, } from "lucide-react";
 
-import {cn} from "@/lib/utils";
+import { cn } from "@/lib/utils";
 
-import {Button} from "@/components/ui/button";
-import {Badge} from "@/components/ui/badge";
-import {Popover, PopoverContent, PopoverTrigger,} from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Popover, PopoverContent, PopoverTrigger, } from "@/components/ui/popover";
 import {
     Command,
     CommandEmpty,
@@ -18,7 +18,7 @@ import {
     CommandList,
     CommandSeparator,
 } from "@/components/ui/command";
-import {Separator} from "@/components/ui/separator.tsx";
+import { Separator } from "@/components/ui/separator.tsx";
 
 /**
  * Variants for the multi-select component to handle different styles.
@@ -49,7 +49,7 @@ const multiSelectVariants = cva(
  */
 interface MultiSelectProps
     extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-        VariantProps<typeof multiSelectVariants> {
+    VariantProps<typeof multiSelectVariants> {
     /**
      * An array of option objects to be displayed in the multi-select component.
      * Each option object has a label, value, and an optional icon.
@@ -208,12 +208,12 @@ export const MultiSelect = React.forwardRef<
                                                 key={value}
                                                 className={cn(
                                                     isAnimating ? "animate-bounce" : "",
-                                                    multiSelectVariants({variant})
+                                                    multiSelectVariants({ variant })
                                                 )}
-                                                style={{animationDuration: `${animation}s`}}
+                                                style={{ animationDuration: `${animation}s` }}
                                             >
                                                 {IconComponent && (
-                                                    <IconComponent className="h-4 w-4 mr-2"/>
+                                                    <IconComponent className="h-4 w-4 mr-2" />
                                                 )}
                                                 {option?.label}
                                                 <XCircle
@@ -231,9 +231,9 @@ export const MultiSelect = React.forwardRef<
                                             className={cn(
                                                 "bg-transparent text-foreground border-foreground/1 hover:bg-transparent",
                                                 isAnimating ? "animate-bounce" : "",
-                                                multiSelectVariants({variant})
+                                                multiSelectVariants({ variant })
                                             )}
-                                            style={{animationDuration: `${animation}s`}}
+                                            style={{ animationDuration: `${animation}s` }}
                                         >
                                             {`+ ${selectedValues.length - maxCount} more`}
                                             <XCircle
@@ -258,15 +258,15 @@ export const MultiSelect = React.forwardRef<
                                         orientation="vertical"
                                         className="flex min-h-6 h-full"
                                     />
-                                    <ChevronDown className="h-4 mx-2 cursor-pointer text-muted-foreground"/>
+                                    <ChevronDown className="h-4 mx-2 cursor-pointer text-muted-foreground" />
                                 </div>
                             </div>
                         ) : (
                             <div className="flex items-center justify-between w-full mx-auto">
-                <span className="text-sm text-muted-foreground mx-3">
-                  {placeholder}
-                </span>
-                                <ChevronDown className="h-4 cursor-pointer text-muted-foreground mx-2"/>
+                                <span className="text-sm text-muted-foreground mx-3">
+                                    {placeholder}
+                                </span>
+                                <ChevronDown className="h-4 cursor-pointer text-muted-foreground mx-2" />
                             </div>
                         )}
                     </Button>
@@ -297,7 +297,7 @@ export const MultiSelect = React.forwardRef<
                                                 : "opacity-50 [&_svg]:invisible"
                                         )}
                                     >
-                                        <CheckIcon className="h-4 w-4"/>
+                                        <CheckIcon className="h-4 w-4" />
                                     </div>
                                     <span>(Select All)</span>
                                 </CommandItem>
@@ -306,6 +306,7 @@ export const MultiSelect = React.forwardRef<
                                     return (
                                         <CommandItem
                                             key={option.value}
+                                            value={option.value}
                                             onSelect={() => toggleOption(option.value)}
                                             className="cursor-pointer"
                                         >
@@ -317,17 +318,17 @@ export const MultiSelect = React.forwardRef<
                                                         : "opacity-50 [&_svg]:invisible"
                                                 )}
                                             >
-                                                <CheckIcon className="h-4 w-4"/>
+                                                <CheckIcon className="h-4 w-4" />
                                             </div>
                                             {option.icon && (
-                                                <option.icon className="mr-2 h-4 w-4 text-muted-foreground"/>
+                                                <option.icon className="mr-2 h-4 w-4 text-muted-foreground" />
                                             )}
                                             <span>{option.label}</span>
                                         </CommandItem>
                                     );
                                 })}
                             </CommandGroup>
-                            <CommandSeparator/>
+                            <CommandSeparator />
                             <CommandGroup>
                                 <div className="flex items-center justify-between">
                                     {selectedValues.length > 0 && (


### PR DESCRIPTION
## Summary
- Fix MultiSelect search by explicitly setting cmdk CommandItem `value` so filtering matches option values.
- Add regression test covering search by value (label differs from value).

## Test plan
- [x] `npm test -- --run src/components/ui/multi-select.test.tsx`